### PR TITLE
Add verify clients usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ docker run -e DERP_DOMAIN=derper.your-domain.com -p 80:80 -p 443:443 -p 3478:347
 # Usage
 
 Fully DERP setup offical documentation: https://tailscale.com/kb/1118/custom-derp-servers/
+
+## Client verification
+
+In order to use `DERP_VERIFY_CLIENTS`, the container needs access to Tailscale's Local API, which can usually be accessed through `/var/run/tailscale/tailscaled.sock`. If you're running Tailscale bare-metal on Linux, adding this to the `docker run` command should be enough: `-v /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock`


### PR DESCRIPTION
The current README contains little information on how to configure `DERP_VERIFY_CLIENTS`. This PR changes that.