### PR TITLE
feat: add DERP_VERIFY_CLIENT_URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ENV DERP_STUN true
 ENV DERP_STUN_PORT 3478
 ENV DERP_HTTP_PORT 80
 ENV DERP_VERIFY_CLIENTS false
+ENV DERP_VERIFY_CLIENT_URL ""
 
 COPY --from=builder /go/bin/derper .
 
@@ -32,5 +33,6 @@ CMD /app/derper --hostname=$DERP_DOMAIN \
     --stun=$DERP_STUN  \
     --stun-port=$DERP_STUN_PORT \
     --http-port=$DERP_HTTP_PORT \
-    --verify-clients=$DERP_VERIFY_CLIENTS
+    --verify-clients=$DERP_VERIFY_CLIENTS \
+    --verify-client-url=$DERP_VERIFY_CLIENT_URL
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,17 @@
 docker run -e DERP_DOMAIN=derper.your-domain.com -p 80:80 -p 443:443 -p 3478:3478/udp fredliang/derper
 ```
 
-| env                 | required | description                                                            | default value     |
-| ------------------- | -------- | ---------------------------------------------------------------------- | ----------------- |
-| DERP_DOMAIN         | true     | derper server hostname                                                 | your-hostname.com |
-| DERP_CERT_DIR       | false    | directory to store LetsEncrypt certs(if addr's port is :443)           | /app/certs        |
-| DERP_CERT_MODE      | false    | mode for getting a cert. possible options: manual, letsencrypt         | letsencrypt       |
-| DERP_ADDR           | false    | listening server address                                               | :443              |
-| DERP_STUN           | false    | also run a STUN server                                                 | true              |
-| DERP_STUN_PORT      | false    | The UDP port on which to serve STUN.                                   | 3478              |
-| DERP_HTTP_PORT      | false    | The port on which to serve HTTP. Set to -1 to disable                  | 80                |
-| DERP_VERIFY_CLIENTS | false    | verify clients to this DERP server through a local tailscaled instance | false             |
+| env                    | required | description                                                                 | default value     |
+| -------------------    | -------- | ----------------------------------------------------------------------      | ----------------- |
+| DERP_DOMAIN            | true     | derper server hostname                                                      | your-hostname.com |
+| DERP_CERT_DIR          | false    | directory to store LetsEncrypt certs(if addr's port is :443)                | /app/certs        |
+| DERP_CERT_MODE         | false    | mode for getting a cert. possible options: manual, letsencrypt              | letsencrypt       |
+| DERP_ADDR              | false    | listening server address                                                    | :443              |
+| DERP_STUN              | false    | also run a STUN server                                                      | true              |
+| DERP_STUN_PORT         | false    | The UDP port on which to serve STUN.                                        | 3478              |
+| DERP_HTTP_PORT         | false    | The port on which to serve HTTP. Set to -1 to disable                       | 80                |
+| DERP_VERIFY_CLIENTS    | false    | verify clients to this DERP server through a local tailscaled instance      | false             |
+| DERP_VERIFY_CLIENT_URL | false    | if non-empty, an admission controller URL for permitting client connections | ""                |
 
 # Usage
 


### PR DESCRIPTION
Add the `DERP_VERIFY_CLIENT_URL` parameter. Referring to <https://github.com/tailscale/tailscale/blob/964282d34f06ecc06ce644769c66b0b31d118340/cmd/derper/derper.go#L60>, when `DERP_VERIFY_CLIENT_URL` is not empty, Derp will query the management server to determine if it should serve a particular client.

By using `DERP_VERIFY_CLIENT_URL`, I can avoid installing Tailscale on the node where Derp is located and accessing the socket through `verify-clients`, instead opting to access an external server via HTTP, thereby reducing operational costs.

For more information, you can also refer to <https://github.com/juanfont/headscale/pull/1957>.